### PR TITLE
Fix issue #141 (in main repo)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,11 +42,7 @@
     {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
   {{ end }}
   {{ end }}
-  {{ if .Site.GoogleAnalytics }}
-  {{ if .Site.Params.googleAnalyticsAsync }}
-    {{ template "_internal/google_analytics_async.html" . }}
-  {{ else }}
+  {{ if .Site.Config.Services.GoogleAnalytics.ID }}
     {{ template "_internal/google_analytics.html" . }}
-  {{ end }}
   {{ end }}
 </head>


### PR DESCRIPTION
_internal/google_analytics_async.html has been deprecated.

Fixes issue: https://github.com/monkeyWzr/hugo-theme-cactus/issues/141